### PR TITLE
fix get_by_name call in flask_server.py.

### DIFF
--- a/flask_server.py
+++ b/flask_server.py
@@ -170,6 +170,8 @@ def common_request():
         interface = interface_manager.get_by_type_size(size_string, request.json['model_type'])
     elif 'model_name' in request.json:
         interface = interface_manager.get_by_name(size_string, request.json['model_name'])
+        key = request.json['model_name'] + '&' + size_string
+        interface = interface_manager.get_by_name(key)
     else:
         interface = interface_manager.get_by_size(size_string)
 


### PR DESCRIPTION
The call get_by_name in https://github.com/kerlomz/captcha_platform/blob/a6a1ae058f8be87ce8527b5630605e3db36efee8/flask_server.py#L172 is wrong. If use it by the way like that will never can not get other model interface, and only can get the default model interface, if default model interface is define.